### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/OldSkoolzRoolz/ai-assisted-it-manager/security/code-scanning/1](https://github.com/OldSkoolzRoolz/ai-assisted-it-manager/security/code-scanning/1)

To rectify the detected problem, add a `permissions` block with the lowest necessary privileges. For typical .NET build workflows, the minimal required permission is usually `contents: read`. This can be added at the workflow root level (before the `jobs:` key), applying to all jobs in the workflow unless any specify another permissions block. Specifically, insert the following block after the `name:` line and before the `on:` or `jobs:` section in `.github/workflows/dotnet.yml`:

```yaml
permissions:
  contents: read
```

No other imports, methods, or definitions are required. In this case, only a YAML edit is necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
