### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build-and-test:
+    permissions:
+      contents: read
     runs-on: windows-latest
     
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/OldSkoolzRoolz/ai-assisted-it-manager/security/code-scanning/2](https://github.com/OldSkoolzRoolz/ai-assisted-it-manager/security/code-scanning/2)

To fix the problem, explicitly define a `permissions` block limiting the privileges of the GITHUB_TOKEN for the job. The best and simplest approach is to add `permissions: contents: read` at the job level (`build-and-test`) or at the top (root) of the workflow. Since the job interacts with the repository source code (requires reading content for builds and tests), but does not perform actions such as pushing commits, managing issues, or publishing packages, `contents: read` is sufficient and is the minimal required permission.

**What to change:**  
- In `.github/workflows/dotnet-ci.yml`, add the following lines under the `build-and-test:` job key (before or after `runs-on: windows-latest`).  
- Alternatively, place it at the root (preferred if all jobs should inherit), right after the top-level `name:` or `on:` block (before `jobs:`).

Here we’ll do the job-level fix as per CodeQL’s suggestion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
